### PR TITLE
feat: migrate to dynamic device matrix from configs/ (main)

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -349,7 +349,7 @@ runs:
         else
           echo "Kernel >= $MIN_VERSION, skipping ptrace patch"
         fi
-        if [ "${{ inputs.model }}" == "OPAce5Pro" ] || [ "${{ inputs.model }}" == "OP13-PJZ" ] || [ "${{ inputs.model }}" == "OP13-CPH" ]; then
+        if [ "${{ inputs.model }}" == "OP-ACE-5-PRO" ] || [ "${{ inputs.model }}" == "OP13-PJZ" ] || [ "${{ inputs.model }}" == "OP13-CPH" ]; then
           echo "Patching hmbird!"
           echo 'obj-y += hmbird_patch.o' >> ./drivers/Makefile
           patch -p1 -F 3 < "../../../kernel_patches/oneplus/hmbird/hmbird_kernel_patch.patch"
@@ -358,7 +358,7 @@ runs:
           rm -rf ext.c ext.h build_policy.c slim.h slim_sysctl.c
           patch -p1 -F 3 < "../../../../../kernel_patches/oneplus/hmbird/hmbird_files_patch.patch"
         else
-          echo "Not OPAce5Pro / OP13-PJZ / OP13-CPH , skipping fengchi patch"
+          echo "Not OP-ACE-5-PRO / OP13-PJZ / OP13-CPH , skipping fengchi patch"
         fi
 
     - name: Apply KSUN Hooks
@@ -593,7 +593,7 @@ runs:
         cd "$GITHUB_WORKSPACE/AnyKernel3"
     
         # Optional hmbird patch logic
-        if [ "${{ inputs.model }}" == "OPAce5Pro" ] || [ "${{ inputs.model }}" == "OP13-PJZ" ] || [ "${{ inputs.model }}" == "OP13-CPH" ]; then
+        if [ "${{ inputs.model }}" == "OP-ACE-5-PRO" ] || [ "${{ inputs.model }}" == "OP13-PJZ" ] || [ "${{ inputs.model }}" == "OP13-CPH" ]; then
           cp "$GITHUB_WORKSPACE/kernel_patches/oneplus/hmbird/bins/"* ./tools/ 2>/dev/null || true
           patch -F 3 < "$GITHUB_WORKSPACE/kernel_patches/oneplus/hmbird/ak3_hmbird_patch.patch"
         fi

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -5,16 +5,8 @@ permissions:
   actions: write
 
 inputs:
-  model:
-    required: true
-    type: string
-  soc:
-    required: true
-    type: string
-  branch:
-    required: true
-    type: string
-  manifest:
+  op_config_json:
+    description: 'JSON string containing full device config'
     required: true
     type: string
   ksun_branch:
@@ -45,15 +37,24 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Parse op_config_json
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo '${{ inputs.op_config_json }}' > /tmp/config.json
+        jq -r 'to_entries[] | "OP_\(.key | ascii_upcase)=\(.value)"' /tmp/config.json >> "$GITHUB_ENV"
+        echo "Parsed config:"
+        jq '.' /tmp/config.json
+
     - name: Validate Inputs
       shell: bash
       run: |
         set -euo pipefail
         echo "::group::Validate inputs"
-        model='${{ inputs.model }}'
-        soc='${{ inputs.soc }}'
-        branch='${{ inputs.branch }}'
-        manifest='${{ inputs.manifest }}'
+        model="$OP_MODEL"
+        soc="$OP_SOC"
+        branch="$OP_BRANCH"
+        manifest="$OP_MANIFEST"
         optimize='${{ inputs.optimize_level }}'
     
         # Non-empty checks
@@ -113,7 +114,7 @@ runs:
       run: |
         set -euo pipefail
         # Derive a unique build directory name
-        CONFIG="${{ inputs.model }}"
+        CONFIG="$OP_MODEL"
         echo "CONFIG=$CONFIG" >> "$GITHUB_ENV"
         # Install repo tool if missing
         REPO="/usr/local/bin/repo"
@@ -131,12 +132,12 @@ runs:
         mkdir -p "$CONFIG"
         cd "$CONFIG"
         echo "Initializing and syncing kernel source..."
-        if [[ "${{ inputs.manifest }}" == https://* ]]; then
+        if [[ "$OP_MANIFEST" == https://* ]]; then
           mkdir -p .repo/manifests
-          curl --fail --show-error --location --proto '=https' "${{ inputs.manifest }}" -o .repo/manifests/temp_manifest.xml
+          curl --fail --show-error --location --proto '=https' "$OP_MANIFEST" -o .repo/manifests/temp_manifest.xml
           "$REPO" init -u https://github.com/OnePlusOSS/kernel_manifest.git -b oneplus/sm8650 -m temp_manifest.xml --repo-rev=v2.16 --depth=1 --no-clone-bundle --no-tags
         else
-          "$REPO" init -u https://github.com/OnePlusOSS/kernel_manifest.git -b "${{ inputs.branch }}" -m "${{ inputs.manifest }}" --repo-rev=v2.16 --depth=1 --no-clone-bundle --no-tags
+          "$REPO" init -u https://github.com/OnePlusOSS/kernel_manifest.git -b "$OP_BRANCH" -m "$OP_MANIFEST" --repo-rev=v2.16 --depth=1 --no-clone-bundle --no-tags
         fi
         "$REPO" --version
         success=false
@@ -181,7 +182,7 @@ runs:
         SUBLEVEL=$(grep '^SUBLEVEL *=' Makefile | awk '{print $3}')
         FULL_VERSION="$VERSION.$PATCHLEVEL.$SUBLEVEL"
         cd "$ARTIFACTS_DIR"
-        echo "$ANDROID_VERSION-$FULL_VERSION" > "${{ inputs.model }}.txt"
+        echo "$ANDROID_VERSION-$FULL_VERSION" > "${OP_MODEL}.txt"
         echo "ANDROID_VER=$ANDROID_VERSION" >> "$GITHUB_ENV"
         echo "KERNEL_VER=$VERSION.$PATCHLEVEL" >> "$GITHUB_ENV"
         echo "KERNEL_FULL_VER=$ANDROID_VERSION-$FULL_VERSION" >> "$GITHUB_ENV"
@@ -349,7 +350,7 @@ runs:
         else
           echo "Kernel >= $MIN_VERSION, skipping ptrace patch"
         fi
-        if [ "${{ inputs.model }}" == "OP-ACE-5-PRO" ] || [ "${{ inputs.model }}" == "OP13-PJZ" ] || [ "${{ inputs.model }}" == "OP13-CPH" ]; then
+        if [ "$OP_HMBIRD" = true ]; then
           echo "Patching hmbird!"
           echo 'obj-y += hmbird_patch.o' >> ./drivers/Makefile
           patch -p1 -F 3 < "../../../kernel_patches/oneplus/hmbird/hmbird_kernel_patch.patch"
@@ -593,12 +594,12 @@ runs:
         cd "$GITHUB_WORKSPACE/AnyKernel3"
     
         # Optional hmbird patch logic
-        if [ "${{ inputs.model }}" == "OP-ACE-5-PRO" ] || [ "${{ inputs.model }}" == "OP13-PJZ" ] || [ "${{ inputs.model }}" == "OP13-CPH" ]; then
+        if [ "$OP_HMBIRD" = true ]; then
           cp "$GITHUB_WORKSPACE/kernel_patches/oneplus/hmbird/bins/"* ./tools/ 2>/dev/null || true
           patch -F 3 < "$GITHUB_WORKSPACE/kernel_patches/oneplus/hmbird/ak3_hmbird_patch.patch"
         fi
         
-        ZIP_NAME="AnyKernel3_${{ inputs.model }}_${{ env.KERNEL_FULL_VER }}_Next_${KSUVER}_${SUSVER}.zip"
+        ZIP_NAME="AnyKernel3_${OP_MODEL}_${{ env.KERNEL_FULL_VER }}_Next_${KSUVER}_${SUSVER}.zip"
         ARTIFACTS_DIR="$CONFIG_DIR/artifacts"
         mkdir -p "$ARTIFACTS_DIR"
     
@@ -606,7 +607,7 @@ runs:
         ( cd "$GITHUB_WORKSPACE/AnyKernel3" && zip -r "$ARTIFACTS_DIR/$ZIP_NAME" ./* >/dev/null )
     
         # Keep only the flashable zip and the model metadata file (assumed already created earlier)
-        find "$ARTIFACTS_DIR" -maxdepth 1 -type f ! -name "$ZIP_NAME" ! -name "${{ inputs.model }}.txt" -delete
+        find "$ARTIFACTS_DIR" -maxdepth 1 -type f ! -name "$ZIP_NAME" ! -name "${OP_MODEL}.txt" -delete
     
         # Output for later steps (optional)
         echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
@@ -616,7 +617,7 @@ runs:
       run: |
         set -euo pipefail
         {
-          echo "Model: ${{ inputs.model }}"
+          echo "Model: ${OP_MODEL}"
           echo "Android: ${{ env.ANDROID_VER }}"
           echo "Kernel base: ${{ env.KERNEL_VER }}"
           echo "Kernel full: ${{ env.KERNEL_FULL_VER }}"
@@ -633,7 +634,7 @@ runs:
         {
           echo "### Kernel Build Summary"
           echo ""
-          echo "- Model: ${{ inputs.model }}"
+          echo "- Model: ${OP_MODEL}"
           echo "- Android: ${{ env.ANDROID_VER }}"
           echo "- Kernel Version: ${{ steps.save_metadata.outputs.kernel_version }}"
           echo "- Kernel Uname: ${{ env.KERNEL_UNAME }}"

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -39,7 +39,7 @@ on:
           - OP-NORD-4
           - OP-NORD-4-CE
           - OP-NORD-CE4-LITE
-          - OPAce5Pro
+          - OP-ACE-5-PRO
           - OP-ACE-5
           - OP-ACE-3-PRO
           - OP-ACE-3V

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -12,6 +12,45 @@ on:
         required: true
         type: boolean
         default: false
+      op_model:
+        description: 'Select the OnePlus kernels to build'
+        required: true
+        type: choice
+        options:
+          - ALL
+          - android15-6.6
+          - android14-6.1
+          - android14-5.15
+          - android13-5.15
+          - android13-5.10
+          - android12-5.10
+          - OP13-CPH
+          - OP13-PJZ
+          - OP13r
+          - OP13S
+          - OP13T
+          - OP12
+          - OP12r
+          - OP11
+          - OP11r
+          - OP10pro
+          - OP10t
+          - OP-Nord-5
+          - OP-NORD-4
+          - OP-NORD-4-CE
+          - OP-NORD-CE4-LITE
+          - OPAce5Pro
+          - OP-ACE-5
+          - OP-ACE-3-PRO
+          - OP-ACE-3V
+          - OP-ACE-2-PRO
+          - OP-ACE-2
+          - OP-OPEN
+          - OP-PAD-3
+          - OP-PAD-2-PRO
+          - OP-PAD-2
+          - OP-PAD-PRO
+        default: ALL
       ksun_branch:
         description: 'Enter KernelSU Next Branch or commit hash (blank for stable tag)'
         required: true
@@ -49,172 +88,82 @@ on:
         default: ''
 
 jobs:
+  set-op-model:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout Code (to access configs/)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            configs/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup OnePlus Model
+        id: set-matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          declare -a models=()
+          while IFS= read -r -d '' file; do
+            model=$(basename "$file" .json)
+            models+=("$model")
+          done < <(find configs/ -name "*.json" -print0)
+        
+          if [ ${#models[@]} -eq 0 ]; then
+            echo "Error: No config files found in configs/ directory!"
+            exit 1
+          fi
+        
+          echo "[" > matrix.json
+          for i in "${!models[@]}"; do
+            model="${models[$i]}"
+            file="configs/$model.json"
+            if [ -f "$file" ]; then
+              jq -r --arg model "$model" '
+                {
+                  model: $model,
+                  soc: .soc,
+                  branch: .branch,
+                  manifest: .manifest,
+                  android_version: .android_version,
+                  kernel_version: .kernel_version
+                }
+              ' "$file" >> matrix.json
+              if [ $((i+1)) -lt ${#models[@]} ]; then
+                echo "," >> matrix.json
+              fi
+            fi
+          done
+          echo "]" >> matrix.json
+        
+          input="${{ github.event.inputs.op_model }}"
+          jq_filter="."
+        
+          if [[ "$input" == "ALL" ]]; then
+            :
+          elif [[ "$input" == android*-* ]]; then
+            IFS='-' read -r av kv <<< "$input"
+            jq_filter="map(select(.android_version == \"$av\" and .kernel_version == \"$kv\"))"
+          else
+            jq_filter="map(select(.model == \"$input\"))"
+          fi
+        
+          filtered=$(jq -c "$jq_filter" matrix.json)
+          wrapped=$(jq -n --argjson items "$filtered" '{ include: $items }')
+        
+          echo "matrix<<MATRIX_EOF" >> "$GITHUB_OUTPUT"
+          echo "$wrapped" >> "$GITHUB_OUTPUT"
+          echo "MATRIX_EOF" >> "$GITHUB_OUTPUT"
+
   build:
     name: build (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+    needs: set-op-model
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-        # batch-1
-        - model: OP11
-          soc: kalama
-          branch: oneplus/sm8550
-          manifest: oneplus_11_v.xml
-          android_version: android13
-          kernel_version: '5.15'
-        - model: OP13-PJZ
-          soc: sun
-          branch: oneplus/sm8750
-          manifest: oneplus_13.xml
-          android_version: android15
-          kernel_version: '6.6'
-        - model: OP13-CPH
-          soc: sun
-          branch: oneplus/sm8750
-          manifest: oneplus_13_global.xml
-          android_version: android15
-          kernel_version: '6.6'
-        - model: OPAce5Pro
-          soc: sun
-          branch: oneplus/sm8750
-          manifest: oneplus_ace5_pro.xml
-          android_version: android15
-          kernel_version: '6.6'
-        - model: OP13S
-          soc: sun
-          branch: oneplus/sm8750
-          manifest: oneplus_13s.xml
-          android_version: android15
-          kernel_version: '6.6'
-        - model: OP-PAD-3
-          soc: sun
-          branch: oneplus/sm8750
-          manifest: oneplus_pad_3.xml
-          android_version: android15
-          kernel_version: '6.6'
-        - model: OP13T
-          soc: sun
-          branch: oneplus/sm8750
-          manifest: oneplus_13t.xml
-          android_version: android15
-          kernel_version: '6.6'
-        - model: OP-PAD-2-PRO
-          soc: sun
-          branch: oneplus/sm8750
-          manifest: oneplus_pad_2_pro.xml
-          android_version: android15
-          kernel_version: '6.6'
-        # batch-2
-        - model: OP12
-          soc: pineapple
-          branch: oneplus/sm8650
-          manifest: oneplus12_v.xml
-          android_version: android14
-          kernel_version: '6.1'
-        - model: OP13r
-          soc: pineapple
-          branch: oneplus/sm8650
-          manifest: oneplus_13r.xml
-          android_version: android14
-          kernel_version: '6.1'
-        - model: OP-ACE-5
-          soc: pineapple
-          branch: oneplus/sm8650
-          manifest: oneplus_ace5.xml
-          android_version: android14
-          kernel_version: '6.1'
-        - model: OP-ACE-3V
-          soc: pineapple
-          branch: oneplus/sm7675
-          manifest: oneplus_ace_3v_v.xml
-          android_version: android14
-          kernel_version: '6.1'
-        - model: OP-NORD-4
-          soc: pineapple
-          branch: oneplus/sm7675
-          manifest: oneplus_nord_4_v.xml
-          android_version: android14
-          kernel_version: '6.1'
-        - model: OP-Nord-5
-          soc: cliffs
-          branch: oneplus/sm8635
-          manifest: oneplus_nord_5.xml
-          android_version: android14
-          kernel_version: "6.1"
-        - model: OP-PAD-2
-          soc: pineapple
-          branch: oneplus/sm8650
-          manifest: oneplus_pad2_v.xml
-          android_version: android14
-          kernel_version: '6.1'
-        - model: OP-Ace3-Pro
-          soc: pineapple
-          branch: oneplus/sm8650
-          manifest: oneplus_ace3_pro_v.xml
-          android_version: android14
-          kernel_version: '6.1'
-        - model: OP-Nord-CE4-LITE
-          soc: blair
-          branch: oneplus/sm6375
-          manifest: oneplus_nord_ce4_lite_5g_v.xml
-          android_version: android14
-          kernel_version: "6.1"
-        - model: OP-PAD-Pro
-          soc: pineapple
-          branch: oneplus/sm8650
-          manifest: oneplus_pad_pro_v.xml
-          android_version: android14
-          kernel_version: '6.1'
-        # batch-3
-        - model: OP11r
-          soc: waipio
-          branch: oneplus/sm8475
-          manifest: oneplus_11r_v.xml
-          android_version: android12
-          kernel_version: '5.10'
-        - model: OP-OPEN
-          soc: kalama
-          branch: oneplus/sm8550
-          manifest: oneplus_open_v.xml
-          android_version: android13
-          kernel_version: '5.15'
-        - model: OP-ACE-2
-          soc: waipio
-          branch: oneplus/sm8475
-          manifest: oneplus_ace2_v.xml
-          android_version: android12
-          kernel_version: '5.10'
-        - model: OP10t
-          soc: waipio
-          branch: oneplus/sm8475
-          manifest: oneplus_10t_v.xml
-          android_version: android12
-          kernel_version: '5.10'
-        - model: OP-Nord-4-CE
-          soc: crow
-          branch: oneplus/sm7550
-          manifest: oneplus_nord_ce4_v.xml
-          android_version: android13
-          kernel_version: "5.15"
-        - model: OP10pro
-          soc: waipio
-          branch: oneplus/sm8450
-          manifest: oneplus_10_pro_v.xml
-          android_version: android12
-          kernel_version: '5.10'
-        - model: OP-ACE-2-PRO
-          soc: kalama
-          branch: oneplus/sm8550
-          manifest: oneplus_ace2_pro_v.xml
-          android_version: android13
-          kernel_version: '5.15'
-        - model: OP12r
-          soc: kalama
-          branch: oneplus/sm8550
-          manifest: oneplus_12r_v.xml
-          android_version: android13
-          kernel_version: '5.15'
+      matrix: ${{ fromJSON(needs.set-op-model.outputs.matrix) }}
     steps:
       - name: Resolve SUSFS branch from inputs
         id: susfs

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -121,16 +121,7 @@ jobs:
             model="${models[$i]}"
             file="configs/$model.json"
             if [ -f "$file" ]; then
-              jq -r --arg model "$model" '
-                {
-                  model: $model,
-                  soc: .soc,
-                  branch: .branch,
-                  manifest: .manifest,
-                  android_version: .android_version,
-                  kernel_version: .kernel_version
-                }
-              ' "$file" >> matrix.json
+              jq -r '.' "$file" >> matrix.json
               if [ $((i+1)) -lt ${#models[@]} ]; then
                 echo "," >> matrix.json
               fi
@@ -194,10 +185,7 @@ jobs:
       - name: Build Kernel
         uses: ./.github/actions
         with:
-          model: ${{ matrix.model }}
-          soc: ${{ matrix.soc }}
-          branch: ${{ matrix.branch }}
-          manifest: ${{ matrix.manifest }}
+          op_config_json: ${{ toJSON(matrix) }}
           ksun_branch: ${{ inputs.ksun_branch }}
           susfs_commit_hash_or_branch: ${{ steps.susfs.outputs.susfs_branch }}
           optimize_level: ${{ inputs.optimize_level }}

--- a/configs/OP-ACE-2-PRO.json
+++ b/configs/OP-ACE-2-PRO.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-ACE-2-PRO",
+  "soc":"kalama",
+  "branch":"oneplus/sm8550",
+  "manifest":"oneplus_ace2_pro_v.xml",
+  "android_version":"android13",
+  "kernel_version":"5.15"
+}

--- a/configs/OP-ACE-2-PRO.json
+++ b/configs/OP-ACE-2-PRO.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-ACE-2-PRO",
-  "soc":"kalama",
-  "branch":"oneplus/sm8550",
-  "manifest":"oneplus_ace2_pro_v.xml",
-  "android_version":"android13",
-  "kernel_version":"5.15"
+  "model": "OP-ACE-2-PRO",
+  "soc": "kalama",
+  "branch": "oneplus/sm8550",
+  "manifest": "oneplus_ace2_pro_v.xml",
+  "android_version": "android13",
+  "kernel_version": "5.15",
+  "hmbird": false
 }

--- a/configs/OP-ACE-2.json
+++ b/configs/OP-ACE-2.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-ACE-2",
+  "soc":"waipio",
+  "branch":"oneplus/sm8475",
+  "manifest":"oneplus_ace2_v.xml",
+  "android_version":"android12",
+  "kernel_version":"5.10"
+}

--- a/configs/OP-ACE-2.json
+++ b/configs/OP-ACE-2.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-ACE-2",
-  "soc":"waipio",
-  "branch":"oneplus/sm8475",
-  "manifest":"oneplus_ace2_v.xml",
-  "android_version":"android12",
-  "kernel_version":"5.10"
+  "model": "OP-ACE-2",
+  "soc": "waipio",
+  "branch": "oneplus/sm8475",
+  "manifest": "oneplus_ace2_v.xml",
+  "android_version": "android12",
+  "kernel_version": "5.10",
+  "hmbird": false
 }

--- a/configs/OP-ACE-3-PRO.json
+++ b/configs/OP-ACE-3-PRO.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-ACE-3-PRO",
+  "soc":"pineapple",
+  "branch":"oneplus/sm8650",
+  "manifest":"oneplus_ace3_pro_v.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-ACE-3-PRO.json
+++ b/configs/OP-ACE-3-PRO.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-ACE-3-PRO",
-  "soc":"pineapple",
-  "branch":"oneplus/sm8650",
-  "manifest":"oneplus_ace3_pro_v.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-ACE-3-PRO",
+  "soc": "pineapple",
+  "branch": "oneplus/sm8650",
+  "manifest": "oneplus_ace3_pro_v.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP-ACE-3V.json
+++ b/configs/OP-ACE-3V.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-ACE-3V",
+  "soc":"pineapple",
+  "branch":"oneplus/sm7675",
+  "manifest":"oneplus_ace_3v_v.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-ACE-3V.json
+++ b/configs/OP-ACE-3V.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-ACE-3V",
-  "soc":"pineapple",
-  "branch":"oneplus/sm7675",
-  "manifest":"oneplus_ace_3v_v.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-ACE-3V",
+  "soc": "pineapple",
+  "branch": "oneplus/sm7675",
+  "manifest": "oneplus_ace_3v_v.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP-ACE-5-PRO.json
+++ b/configs/OP-ACE-5-PRO.json
@@ -1,5 +1,5 @@
 {
-  "model":"OPAce5Pro",
+  "model":"OP-ACE-5-PRO",
   "soc":"sun",
   "branch":"oneplus/sm8750",
   "manifest":"oneplus_ace5_pro.xml",

--- a/configs/OP-ACE-5-PRO.json
+++ b/configs/OP-ACE-5-PRO.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-ACE-5-PRO",
-  "soc":"sun",
-  "branch":"oneplus/sm8750",
-  "manifest":"oneplus_ace5_pro.xml",
-  "android_version":"android15",
-  "kernel_version":"6.6"
+  "model": "OP-ACE-5-PRO",
+  "soc": "sun",
+  "branch": "oneplus/sm8750",
+  "manifest": "oneplus_ace5_pro.xml",
+  "android_version": "android15",
+  "kernel_version": "6.6",
+  "hmbird": true
 }

--- a/configs/OP-ACE-5.json
+++ b/configs/OP-ACE-5.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-ACE-5",
+  "soc":"pineapple",
+  "branch":"oneplus/sm8650",
+  "manifest":"oneplus_ace5.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-ACE-5.json
+++ b/configs/OP-ACE-5.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-ACE-5",
-  "soc":"pineapple",
-  "branch":"oneplus/sm8650",
-  "manifest":"oneplus_ace5.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-ACE-5",
+  "soc": "pineapple",
+  "branch": "oneplus/sm8650",
+  "manifest": "oneplus_ace5.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP-NORD-4-CE.json
+++ b/configs/OP-NORD-4-CE.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-NORD-4-CE",
+  "soc":"crow",
+  "branch":"oneplus/sm7550",
+  "manifest":"oneplus_nord_ce4_v.xml",
+  "android_version":"android13",
+  "kernel_version":"5.15"
+}

--- a/configs/OP-NORD-4-CE.json
+++ b/configs/OP-NORD-4-CE.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-NORD-4-CE",
-  "soc":"crow",
-  "branch":"oneplus/sm7550",
-  "manifest":"oneplus_nord_ce4_v.xml",
-  "android_version":"android13",
-  "kernel_version":"5.15"
+  "model": "OP-NORD-4-CE",
+  "soc": "crow",
+  "branch": "oneplus/sm7550",
+  "manifest": "oneplus_nord_ce4_v.xml",
+  "android_version": "android13",
+  "kernel_version": "5.15",
+  "hmbird": false
 }

--- a/configs/OP-NORD-4.json
+++ b/configs/OP-NORD-4.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-NORD-4",
+  "soc":"pineapple",
+  "branch":"oneplus/sm7675",
+  "manifest":"oneplus_nord_4_v.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-NORD-4.json
+++ b/configs/OP-NORD-4.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-NORD-4",
-  "soc":"pineapple",
-  "branch":"oneplus/sm7675",
-  "manifest":"oneplus_nord_4_v.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-NORD-4",
+  "soc": "pineapple",
+  "branch": "oneplus/sm7675",
+  "manifest": "oneplus_nord_4_v.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP-NORD-5.json
+++ b/configs/OP-NORD-5.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-NORD-5",
-  "soc":"cliffs",
-  "branch":"oneplus/sm8635",
-  "manifest":"oneplus_nord_5.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-NORD-5",
+  "soc": "cliffs",
+  "branch": "oneplus/sm8635",
+  "manifest": "oneplus_nord_5.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP-NORD-5.json
+++ b/configs/OP-NORD-5.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-NORD-5",
+  "soc":"cliffs",
+  "branch":"oneplus/sm8635",
+  "manifest":"oneplus_nord_5.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-NORD-CE4-LITE.json
+++ b/configs/OP-NORD-CE4-LITE.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-NORD-CE4-LITE",
-  "soc":"blair",
-  "branch":"oneplus/sm6375",
-  "manifest":"oneplus_nord_ce4_lite_5g_v.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-NORD-CE4-LITE",
+  "soc": "blair",
+  "branch": "oneplus/sm6375",
+  "manifest": "oneplus_nord_ce4_lite_5g_v.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP-NORD-CE4-LITE.json
+++ b/configs/OP-NORD-CE4-LITE.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-NORD-CE4-LITE",
+  "soc":"blair",
+  "branch":"oneplus/sm6375",
+  "manifest":"oneplus_nord_ce4_lite_5g_v.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-OPEN.json
+++ b/configs/OP-OPEN.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-OPEN",
-  "soc":"kalama",
-  "branch":"oneplus/sm8550",
-  "manifest":"oneplus_open_v.xml",
-  "android_version":"android13",
-  "kernel_version":"5.15"
+  "model": "OP-OPEN",
+  "soc": "kalama",
+  "branch": "oneplus/sm8550",
+  "manifest": "oneplus_open_v.xml",
+  "android_version": "android13",
+  "kernel_version": "5.15",
+  "hmbird": false
 }

--- a/configs/OP-OPEN.json
+++ b/configs/OP-OPEN.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-OPEN",
+  "soc":"kalama",
+  "branch":"oneplus/sm8550",
+  "manifest":"oneplus_open_v.xml",
+  "android_version":"android13",
+  "kernel_version":"5.15"
+}

--- a/configs/OP-PAD-2-PRO.json
+++ b/configs/OP-PAD-2-PRO.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-PAD-2-PRO",
+  "soc":"sun",
+  "branch":"oneplus/sm8750",
+  "manifest":"oneplus_pad_2_pro.xml",
+  "android_version":"android15",
+  "kernel_version":"6.6"
+}

--- a/configs/OP-PAD-2-PRO.json
+++ b/configs/OP-PAD-2-PRO.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-PAD-2-PRO",
-  "soc":"sun",
-  "branch":"oneplus/sm8750",
-  "manifest":"oneplus_pad_2_pro.xml",
-  "android_version":"android15",
-  "kernel_version":"6.6"
+  "model": "OP-PAD-2-PRO",
+  "soc": "sun",
+  "branch": "oneplus/sm8750",
+  "manifest": "oneplus_pad_2_pro.xml",
+  "android_version": "android15",
+  "kernel_version": "6.6",
+  "hmbird": false
 }

--- a/configs/OP-PAD-2.json
+++ b/configs/OP-PAD-2.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-PAD-2",
+  "soc":"pineapple",
+  "branch":"oneplus/sm8650",
+  "manifest":"oneplus_pad2_v.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-PAD-2.json
+++ b/configs/OP-PAD-2.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-PAD-2",
-  "soc":"pineapple",
-  "branch":"oneplus/sm8650",
-  "manifest":"oneplus_pad2_v.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-PAD-2",
+  "soc": "pineapple",
+  "branch": "oneplus/sm8650",
+  "manifest": "oneplus_pad2_v.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP-PAD-3.json
+++ b/configs/OP-PAD-3.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-PAD-3",
-  "soc":"sun",
-  "branch":"oneplus/sm8750",
-  "manifest":"oneplus_pad_3.xml",
-  "android_version":"android15",
-  "kernel_version":"6.6"
+  "model": "OP-PAD-3",
+  "soc": "sun",
+  "branch": "oneplus/sm8750",
+  "manifest": "oneplus_pad_3.xml",
+  "android_version": "android15",
+  "kernel_version": "6.6",
+  "hmbird": false
 }

--- a/configs/OP-PAD-3.json
+++ b/configs/OP-PAD-3.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-PAD-3",
+  "soc":"sun",
+  "branch":"oneplus/sm8750",
+  "manifest":"oneplus_pad_3.xml",
+  "android_version":"android15",
+  "kernel_version":"6.6"
+}

--- a/configs/OP-PAD-PRO.json
+++ b/configs/OP-PAD-PRO.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP-PAD-PRO",
+  "soc":"pineapple",
+  "branch":"oneplus/sm8650",
+  "manifest":"oneplus_pad_pro_v.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP-PAD-PRO.json
+++ b/configs/OP-PAD-PRO.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP-PAD-PRO",
-  "soc":"pineapple",
-  "branch":"oneplus/sm8650",
-  "manifest":"oneplus_pad_pro_v.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP-PAD-PRO",
+  "soc": "pineapple",
+  "branch": "oneplus/sm8650",
+  "manifest": "oneplus_pad_pro_v.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP10pro.json
+++ b/configs/OP10pro.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP10pro",
-  "soc":"waipio",
-  "branch":"oneplus/sm8450",
-  "manifest":"oneplus_10_pro_v.xml",
-  "android_version":"android12",
-  "kernel_version":"5.10"
+  "model": "OP10pro",
+  "soc": "waipio",
+  "branch": "oneplus/sm8450",
+  "manifest": "oneplus_10_pro_v.xml",
+  "android_version": "android12",
+  "kernel_version": "5.10",
+  "hmbird": false
 }

--- a/configs/OP10pro.json
+++ b/configs/OP10pro.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP10pro",
+  "soc":"waipio",
+  "branch":"oneplus/sm8450",
+  "manifest":"oneplus_10_pro_v.xml",
+  "android_version":"android12",
+  "kernel_version":"5.10"
+}

--- a/configs/OP10t.json
+++ b/configs/OP10t.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP10t",
+  "soc":"waipio",
+  "branch":"oneplus/sm8475",
+  "manifest":"oneplus_10t_v.xml",
+  "android_version":"android12",
+  "kernel_version":"5.10"
+}

--- a/configs/OP10t.json
+++ b/configs/OP10t.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP10t",
-  "soc":"waipio",
-  "branch":"oneplus/sm8475",
-  "manifest":"oneplus_10t_v.xml",
-  "android_version":"android12",
-  "kernel_version":"5.10"
+  "model": "OP10t",
+  "soc": "waipio",
+  "branch": "oneplus/sm8475",
+  "manifest": "oneplus_10t_v.xml",
+  "android_version": "android12",
+  "kernel_version": "5.10",
+  "hmbird": false
 }

--- a/configs/OP11.json
+++ b/configs/OP11.json
@@ -4,5 +4,6 @@
   "branch": "oneplus/sm8550",
   "manifest": "oneplus_11_v.xml",
   "android_version": "android13",
-  "kernel_version": "5.15"
+  "kernel_version": "5.15",
+  "hmbird": false
 }

--- a/configs/OP11.json
+++ b/configs/OP11.json
@@ -1,0 +1,8 @@
+{
+  "model": "OP11",
+  "soc": "kalama",
+  "branch": "oneplus/sm8550",
+  "manifest": "oneplus_11_v.xml",
+  "android_version": "android13",
+  "kernel_version": "5.15"
+}

--- a/configs/OP11r.json
+++ b/configs/OP11r.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP11r",
-  "soc":"waipio",
-  "branch":"oneplus/sm8475",
-  "manifest":"oneplus_11r_v.xml",
-  "android_version":"android12",
-  "kernel_version":"5.10"
+  "model": "OP11r",
+  "soc": "waipio",
+  "branch": "oneplus/sm8475",
+  "manifest": "oneplus_11r_v.xml",
+  "android_version": "android12",
+  "kernel_version": "5.10",
+  "hmbird": false
 }

--- a/configs/OP11r.json
+++ b/configs/OP11r.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP11r",
+  "soc":"waipio",
+  "branch":"oneplus/sm8475",
+  "manifest":"oneplus_11r_v.xml",
+  "android_version":"android12",
+  "kernel_version":"5.10"
+}

--- a/configs/OP12.json
+++ b/configs/OP12.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP12",
+  "soc":"pineapple",
+  "branch":"oneplus/sm8650",
+  "manifest":"oneplus12_v.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP12.json
+++ b/configs/OP12.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP12",
-  "soc":"pineapple",
-  "branch":"oneplus/sm8650",
-  "manifest":"oneplus12_v.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP12",
+  "soc": "pineapple",
+  "branch": "oneplus/sm8650",
+  "manifest": "oneplus12_v.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OP12r.json
+++ b/configs/OP12r.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP12r",
+  "soc":"kalama",
+  "branch":"oneplus/sm8550",
+  "manifest":"oneplus_12r_v.xml",
+  "android_version":"android13",
+  "kernel_version":"5.15"
+}

--- a/configs/OP12r.json
+++ b/configs/OP12r.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP12r",
-  "soc":"kalama",
-  "branch":"oneplus/sm8550",
-  "manifest":"oneplus_12r_v.xml",
-  "android_version":"android13",
-  "kernel_version":"5.15"
+  "model": "OP12r",
+  "soc": "kalama",
+  "branch": "oneplus/sm8550",
+  "manifest": "oneplus_12r_v.xml",
+  "android_version": "android13",
+  "kernel_version": "5.15",
+  "hmbird": false
 }

--- a/configs/OP13-CPH.json
+++ b/configs/OP13-CPH.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP13-CPH",
-  "soc":"sun",
-  "branch":"oneplus/sm8750",
-  "manifest":"oneplus_13_global.xml",
-  "android_version":"android15",
-  "kernel_version":"6.6"
+  "model": "OP13-CPH",
+  "soc": "sun",
+  "branch": "oneplus/sm8750",
+  "manifest": "oneplus_13_global.xml",
+  "android_version": "android15",
+  "kernel_version": "6.6",
+  "hmbird": true
 }

--- a/configs/OP13-CPH.json
+++ b/configs/OP13-CPH.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP13-CPH",
+  "soc":"sun",
+  "branch":"oneplus/sm8750",
+  "manifest":"oneplus_13_global.xml",
+  "android_version":"android15",
+  "kernel_version":"6.6"
+}

--- a/configs/OP13-PJZ.json
+++ b/configs/OP13-PJZ.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP13-PJZ",
-  "soc":"sun",
-  "branch":"oneplus/sm8750",
-  "manifest":"oneplus_13.xml",
-  "android_version":"android15",
-  "kernel_version":"6.6"
+  "model": "OP13-PJZ",
+  "soc": "sun",
+  "branch": "oneplus/sm8750",
+  "manifest": "oneplus_13.xml",
+  "android_version": "android15",
+  "kernel_version": "6.6",
+  "hmbird": true
 }

--- a/configs/OP13-PJZ.json
+++ b/configs/OP13-PJZ.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP13-PJZ",
+  "soc":"sun",
+  "branch":"oneplus/sm8750",
+  "manifest":"oneplus_13.xml",
+  "android_version":"android15",
+  "kernel_version":"6.6"
+}

--- a/configs/OP13S.json
+++ b/configs/OP13S.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP13S",
+  "soc":"sun",
+  "branch":"oneplus/sm8750",
+  "manifest":"oneplus_13s.xml",
+  "android_version":"android15",
+  "kernel_version":"6.6"
+}

--- a/configs/OP13S.json
+++ b/configs/OP13S.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP13S",
-  "soc":"sun",
-  "branch":"oneplus/sm8750",
-  "manifest":"oneplus_13s.xml",
-  "android_version":"android15",
-  "kernel_version":"6.6"
+  "model": "OP13S",
+  "soc": "sun",
+  "branch": "oneplus/sm8750",
+  "manifest": "oneplus_13s.xml",
+  "android_version": "android15",
+  "kernel_version": "6.6",
+  "hmbird": false
 }

--- a/configs/OP13T.json
+++ b/configs/OP13T.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP13T",
+  "soc":"sun",
+  "branch":"oneplus/sm8750",
+  "manifest":"oneplus_13t.xml",
+  "android_version":"android15",
+  "kernel_version":"6.6"
+}

--- a/configs/OP13T.json
+++ b/configs/OP13T.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP13T",
-  "soc":"sun",
-  "branch":"oneplus/sm8750",
-  "manifest":"oneplus_13t.xml",
-  "android_version":"android15",
-  "kernel_version":"6.6"
+  "model": "OP13T",
+  "soc": "sun",
+  "branch": "oneplus/sm8750",
+  "manifest": "oneplus_13t.xml",
+  "android_version": "android15",
+  "kernel_version": "6.6",
+  "hmbird": false
 }

--- a/configs/OP13r.json
+++ b/configs/OP13r.json
@@ -1,0 +1,8 @@
+{
+  "model":"OP13r"
+  ,"soc":"pineapple",
+  "branch":"oneplus/sm8650",
+  "manifest":"oneplus_13r.xml",
+  "android_version":"android14",
+  "kernel_version":"6.1"
+}

--- a/configs/OP13r.json
+++ b/configs/OP13r.json
@@ -1,8 +1,9 @@
 {
-  "model":"OP13r"
-  ,"soc":"pineapple",
-  "branch":"oneplus/sm8650",
-  "manifest":"oneplus_13r.xml",
-  "android_version":"android14",
-  "kernel_version":"6.1"
+  "model": "OP13r",
+  "soc": "pineapple",
+  "branch": "oneplus/sm8650",
+  "manifest": "oneplus_13r.xml",
+  "android_version": "android14",
+  "kernel_version": "6.1",
+  "hmbird": false
 }

--- a/configs/OPAce5Pro.json
+++ b/configs/OPAce5Pro.json
@@ -1,0 +1,8 @@
+{
+  "model":"OPAce5Pro",
+  "soc":"sun",
+  "branch":"oneplus/sm8750",
+  "manifest":"oneplus_ace5_pro.xml",
+  "android_version":"android15",
+  "kernel_version":"6.6"
+}


### PR DESCRIPTION
Replace the hardcoded device matrix with a dynamic one loaded from JSON files in configs/. This allows easier maintenance and device onboarding without editing the workflow file.

Also adds a new workflow_dispatch input 'op_model' to selectively build:
- a single device
- all devices
- all devices matching a specific kernel version combo

This change improves scalability and user flexibility during manual workflow dispatch.